### PR TITLE
Add installation testing in both release and devel built images

### DIFF
--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -13,9 +13,9 @@ jobs:
   test-built-containers:
     strategy:
       matrix:
-        container_tag: [devel, RELEASE_3_12]
+        container-tag: [devel, RELEASE_3_12]
     runs-on: ubuntu-latest
-    container: bioconductor/bioconductor_docker:${{container_tag}}
+    container: bioconductor/bioconductor_docker:${{ matrix.container-tag }}
 
     steps:
       - name: Canary package installs from default repositories

--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -1,3 +1,5 @@
+name: test-images-install
+
 on:
   workflow_run:
     workflows: ["weekly-bioconductor-docker-devel-builder"]

--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -1,0 +1,22 @@
+on:
+  push
+  workflow_run:
+    workflows: ["weekly-bioconductor-docker-devel-builder"]
+    types:
+      - completed
+  schedule:
+    - cron: '* */6 * * *'
+
+jobs:
+  test-built-containers:
+    strategy:
+      matrix:
+        container_tag: [devel, RELEASE_3_12]
+    runs-on: ubuntu-latest
+    container: bioconductor/bioconductor_docker:${{container_tag}}
+
+    steps:
+      - name: Canary package installs from default repositories
+        run: |
+          BiocManager::install(c('SummarizedExperiment','usethis','data.table','igraph','GEOquery'))
+        shell: Rscript {0}

--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -1,5 +1,4 @@
 on:
-  push
   workflow_run:
     workflows: ["weekly-bioconductor-docker-devel-builder"]
     types:

--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -1,10 +1,11 @@
 name: test-images-install
 
 on:
-  # workflow_run:
-  #   workflows: ["weekly-bioconductor-docker-devel-builder"]
-  #   types:
-  #     - completed
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["weekly-bioconductor-docker-devel-builder"]
+    types:
+      - completed
   schedule:
     - cron: '* */6 * * *'
 

--- a/.github/workflows/test-images.yaml
+++ b/.github/workflows/test-images.yaml
@@ -1,10 +1,10 @@
 name: test-images-install
 
 on:
-  workflow_run:
-    workflows: ["weekly-bioconductor-docker-devel-builder"]
-    types:
-      - completed
+  # workflow_run:
+  #   workflows: ["weekly-bioconductor-docker-devel-builder"]
+  #   types:
+  #     - completed
   schedule:
     - cron: '* */6 * * *'
 


### PR DESCRIPTION
Fixes #19. 

This GHactions workflow uses the current `devel` and `RELEASE_3_12` images to test installing five packages (see code). Replace packages as needed, but the idea here is to test the actual functionality of the images. Additional tests can be added as needed. This workflow uses an example "matrix" build, so one could, for example, add "repositories" as another variable in the matrix to test against CRAN or RSPM repos. Additional tests including loading packages might be useful. 