### PR TITLE
Add experimental docker compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG BIOCONDUCTOR_VERSION=3.13
 ##### IMPORTANT ########
 ## The PATCH version number should be incremented each time
 ## there is a change in the Dockerfile.
-ARG BIOCONDUCTOR_PATCH=29
+ARG BIOCONDUCTOR_PATCH=30
 ARG BIOCONDUCTOR_DOCKER_VERSION=${BIOCONDUCTOR_VERSION}.${BIOCONDUCTOR_PATCH}
 
 LABEL name="bioconductor/bioconductor_docker" \
@@ -151,8 +151,7 @@ RUN apt-get update \
 	&& rm -rf /var/lib/apt/lists/*
 
 ## Add host-site-library
-RUN echo "R_LIBS=/usr/local/lib/R/host-site-library:\${R_LIBS}" > /usr/local/lib/R/etc/Renviron.site \
-    && echo "options(defaultPackages=c(getOption('defaultPackages'),'BiocManager'))" >> /usr/local/lib/R/etc/Rprofile.site
+RUN echo "R_LIBS=/usr/local/lib/R/host-site-library:\${R_LIBS}" > /usr/local/lib/R/etc/Renviron.site
 
 ADD install.R /tmp/
 

--- a/README.md
+++ b/README.md
@@ -273,14 +273,8 @@ directory,
 docker-compose up 
 ```
 
-To run in the background, use the `-d` or `--detach` flag,
-
-```
-docker-compose up -d
-```
-
-The RStudio image is launched at `http://localhost:8787`. Using
-`docker-compose`, the user can launch the image with a single command.
+Using `docker-compose`, the user can launch the image with a single
+command. The RStudio image is launched at `http://localhost:8787`.
 
 The `docker-composer.yaml` includes settings so that the user doesn't
 have to worry about setting the port, password (default is `bioc`), or
@@ -307,6 +301,24 @@ stored in the same location as well.
 volumes:
 	- ${HOME}/R/bioconductor_docker/3.13:/usr/local/lib/R/host-site-library
 	- ${HOME}/R/data:/home/rstudio
+```
+
+
+To run in the background, use the `-d` or `--detach` flag,
+
+```
+docker-compose up -d
+```
+
+If the image is run in a detached state, the `container-name` can be
+used to exec into the terminal if the user wishes `root` access in a
+terminal, without using RStudio.
+
+Within the `root` user, additional system dependencies can be
+installed to make the image fit the needs of the user.
+
+```
+docker exec -it bioc-3.13 bash
 ```
 
 For more information on how to use `docker-compose`, use the

--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@ or [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/).
 - [Why Use Containers](#intro)
   * [Goals for new containers](#goals)
 - [Current Containers](#current)
+- [Using Containers](#usage)
+  * [Running Containers](#running)
+  * [Mounting Additional Volume](#mounting)
+  * [Using docker-compose](#dockercompose)
+- [Modifying Image Container](#modify)
+- [Singularity](#singularity)
 - [Deprecation Notice](#deprecation)
   * [Legacy Containers](#legacy)
   * [Reason for deprecation](#reason)
   * [Reporting issues](#issues)
-- [Using Containers](#usage)
-  * [Running Containers](#running)
-  * [Mounting Additional Volume](#mounting)
-- [Modifying Image Container](#modify)
-- [Singularity](#singularity)
 - [Acknowledgements](#acknowledgements)
 
 <a name="quickstart"></a>
@@ -121,101 +122,6 @@ For each supported version of Bioconductor, we provide
 
 Bioconductor's Docker images are stored in [Docker Hub](https://hub.docker.com/u/bioconductor/);
 the source Dockerfile(s) are in [Github](https://github.com/Bioconductor/bioconductor_docker).
-
-<a name="deprecation"></a>
-
-## Deprecation Notice
-
-For previous users of docker containers for Bioconductor, please note
-that we are deprecating the following images. These images were
-maintained by Bioconductor Core, and also the community.
-
-<a name="legacy"></a>
-
-### Legacy Containers
-
-These images are NO LONGER MAINTAINED and updated. They will however
-be available to use should a user choose. They are not
-supported anymore by the Bioconductor Core team.
-
-Bioconductor Core Team: bioc-issue-bot@bioconductor.org
-
-* [bioconductor/devel_base2](https://hub.docker.com/r/bioconductor/devel_base2/)
-* [bioconductor/devel_core2](https://hub.docker.com/r/bioconductor/devel_core2/)
-* [bioconductor/release_base2](https://hub.docker.com/r/bioconductor/release_base2/)
-* [bioconductor/release_core2](https://hub.docker.com/r/bioconductor/release_core2/)
-
-Steffen Neumann: sneumann@ipb-halle.de, Maintained as part of the "PhenoMeNal, funded by Horizon2020 grant 654241"
-
-* [bioconductor/devel_protmetcore2](https://hub.docker.com/r/bioconductor/devel_protmetcore2/)
-* [bioconductor/devel_metabolomics2](https://hub.docker.com/r/bioconductor/devel_metabolomics2/)
-* [bioconductor/release_protmetcore2](https://hub.docker.com/r/bioconductor/release_protmetcore2/)
-* [bioconductor/release_metabolomics2](https://hub.docker.com/r/bioconductor/release_metabolomics2/)
-
-Laurent Gatto: lg390@cam.ac.uk
-
-* [bioconductor/devel_mscore2](https://hub.docker.com/r/bioconductor/devel_mscore2/)
-* [bioconductor/devel_protcore2](https://hub.docker.com/r/bioconductor/devel_protcore2/)
-* [bioconductor/devel_proteomics2](https://hub.docker.com/r/bioconductor/devel_proteomics2/)
-* [bioconductor/release_mscore2](https://hub.docker.com/r/bioconductor/release_mscore2/)
-* [bioconductor/release_protcore2](https://hub.docker.com/r/bioconductor/release_protcore2/)
-* [bioconductor/release_proteomics2](https://hub.docker.com/r/bioconductor/release_proteomics2/)
-
-RGLab: wjiang2@fredhutch.org
-
-* [bioconductor/devel_cytometry2](https://hub.docker.com/r/bioconductor/devel_cytometry2/)
-* [bioconductor/release_cytometry2](https://hub.docker.com/r/bioconductor/release_cytometry2/)
-
-First iteration containers
-
-* bioconductor/devel_base
-* bioconductor/devel_core
-* bioconductor/devel_flow
-* bioconductor/devel_microarray
-* bioconductor/devel_proteomics
-* bioconductor/devel_sequencing
-* bioconductor/devel_metabolomics
-* bioconductor/release_base
-* bioconductor/release_core
-* bioconductor/release_flow
-* bioconductor/release_microarray
-* bioconductor/release_proteomics
-* bioconductor/release_sequencing
-* bioconductor/release_metabolomics
-
-<a name="reason"></a>
-
-### Reason for deprecation
-
-The new Bioconductor Docker image `bioconductor/bioconductor_docker`
-makes it possible to easily install any package the user chooses since
-all the system dependencies are built in to this new image. The
-previous images did not have all the system dependencies built in to
-the image. The new installation of packages can be done with,
-
-	BiocManager::install(c("package_name", "package_name"))
-
-Other reasons for deprecation:
-
- - the chain of inheritance of Docker images was too complex and hard
-   to maintain.
-
- - Hard to extend because there were multiple flavors of images.
-
- - Naming convention was making things harder to use.
-
- - Images which were not maintained were not deprecated.
-
-<a name="issues"></a>
-
-### Reporting Issues
-
-Please report issues with the new set of images on [GitHub Issues](https://github.com/Bioconductor/bioconductor_docker/issues) or
-the [Bioc-devel](mailto:bioc-devel@r-project.org) mailing list.
-
-These issues can be questions about anything related to this piece of
-software such as, usage, extending Docker images, enhancements, and
-bug reports.
 
 <a name="usage"></a>
 
@@ -356,6 +262,56 @@ package would be available for use.
 			-p 8787:8787 \
 			bioconductor/bioconductor_docker:devel
 
+<a name="dockercompose"></a>
+
+### Using docker-compose
+
+To run the docker-compose file `docker-compose.yaml` from the same
+directory,
+
+```
+docker-compose up 
+```
+
+To run in the background, use the `-d` or `--detach` flag,
+
+```
+docker-compose up -d
+```
+
+The RStudio image is launched at `http://localhost:8787`. Using
+`docker-compose`, the user can launch the image with a single command.
+
+The `docker-composer.yaml` includes settings so that the user doesn't
+have to worry about setting the port, password (default is `bioc`), or
+the volume to save libraries.
+
+The library path, where all the packages are installed are
+automatically configured to use the volume
+`$HOME/R/bioconductor_docker/<bioconductor_version>`, in the case of
+the Bioconductor version 3.13, it would be
+`$HOME/R/bioconductor_docker/3.13`. This location is mounted on to the
+path, `/usr/local/lib/R/host-site-library`, which is the first value
+in your search path for packages if you check `.libPaths()`.
+
+When the user starts the docker image using `docker-compose`, it will
+recognize previously mounted libraries with the apprpriate
+bioconductor version, and save users time reinstalling the previously
+installed packages.
+
+To add another volume for data, it's possible to modify the
+`docker-compose.yml` to include another volume, so all the data is
+stored in the same location as well.
+
+```
+volumes:
+	- ${HOME}/R/bioconductor_docker/3.13:/usr/local/lib/R/host-site-library
+	- ${HOME}/R/data:/home/rstudio
+```
+
+For more information on how to use `docker-compose`, use the
+[official docker-compose reference](https://docs.docker.com/compose/reference/up/).
+
 <p class="back_to_top">[ <a href="#top">Back to top</a> ]</p>
 
 <a name="modify"></a>
@@ -450,7 +406,6 @@ Example 2:
 
 <p class="back_to_top">[ <a href="#top">Back to top</a> ]</p>
 
-
 ## Singularity
 
 The latest `bioconductor/bioconductor_docker` images are available on
@@ -478,6 +433,101 @@ If Singularity is available,
 
 Please check this link for specific usage instructions relevant to Singularity
 containers: https://singularity-hub.org/collections/3955/usage
+
+<a name="deprecation"></a>
+
+## Deprecation Notice
+
+For previous users of docker containers for Bioconductor, please note
+that we are deprecating the following images. These images were
+maintained by Bioconductor Core, and also the community.
+
+<a name="legacy"></a>
+
+### Legacy Containers
+
+These images are NO LONGER MAINTAINED and updated. They will however
+be available to use should a user choose. They are not
+supported anymore by the Bioconductor Core team.
+
+Bioconductor Core Team: bioc-issue-bot@bioconductor.org
+
+* [bioconductor/devel_base2](https://hub.docker.com/r/bioconductor/devel_base2/)
+* [bioconductor/devel_core2](https://hub.docker.com/r/bioconductor/devel_core2/)
+* [bioconductor/release_base2](https://hub.docker.com/r/bioconductor/release_base2/)
+* [bioconductor/release_core2](https://hub.docker.com/r/bioconductor/release_core2/)
+
+Steffen Neumann: sneumann@ipb-halle.de, Maintained as part of the "PhenoMeNal, funded by Horizon2020 grant 654241"
+
+* [bioconductor/devel_protmetcore2](https://hub.docker.com/r/bioconductor/devel_protmetcore2/)
+* [bioconductor/devel_metabolomics2](https://hub.docker.com/r/bioconductor/devel_metabolomics2/)
+* [bioconductor/release_protmetcore2](https://hub.docker.com/r/bioconductor/release_protmetcore2/)
+* [bioconductor/release_metabolomics2](https://hub.docker.com/r/bioconductor/release_metabolomics2/)
+
+Laurent Gatto: lg390@cam.ac.uk
+
+* [bioconductor/devel_mscore2](https://hub.docker.com/r/bioconductor/devel_mscore2/)
+* [bioconductor/devel_protcore2](https://hub.docker.com/r/bioconductor/devel_protcore2/)
+* [bioconductor/devel_proteomics2](https://hub.docker.com/r/bioconductor/devel_proteomics2/)
+* [bioconductor/release_mscore2](https://hub.docker.com/r/bioconductor/release_mscore2/)
+* [bioconductor/release_protcore2](https://hub.docker.com/r/bioconductor/release_protcore2/)
+* [bioconductor/release_proteomics2](https://hub.docker.com/r/bioconductor/release_proteomics2/)
+
+RGLab: wjiang2@fredhutch.org
+
+* [bioconductor/devel_cytometry2](https://hub.docker.com/r/bioconductor/devel_cytometry2/)
+* [bioconductor/release_cytometry2](https://hub.docker.com/r/bioconductor/release_cytometry2/)
+
+First iteration containers
+
+* bioconductor/devel_base
+* bioconductor/devel_core
+* bioconductor/devel_flow
+* bioconductor/devel_microarray
+* bioconductor/devel_proteomics
+* bioconductor/devel_sequencing
+* bioconductor/devel_metabolomics
+* bioconductor/release_base
+* bioconductor/release_core
+* bioconductor/release_flow
+* bioconductor/release_microarray
+* bioconductor/release_proteomics
+* bioconductor/release_sequencing
+* bioconductor/release_metabolomics
+
+<a name="reason"></a>
+
+### Reason for deprecation
+
+The new Bioconductor Docker image `bioconductor/bioconductor_docker`
+makes it possible to easily install any package the user chooses since
+all the system dependencies are built in to this new image. The
+previous images did not have all the system dependencies built in to
+the image. The new installation of packages can be done with,
+
+	BiocManager::install(c("package_name", "package_name"))
+
+Other reasons for deprecation:
+
+ - the chain of inheritance of Docker images was too complex and hard
+   to maintain.
+
+ - Hard to extend because there were multiple flavors of images.
+
+ - Naming convention was making things harder to use.
+
+ - Images which were not maintained were not deprecated.
+
+<a name="issues"></a>
+
+### Reporting Issues
+
+Please report issues with the new set of images on [GitHub Issues](https://github.com/Bioconductor/bioconductor_docker/issues) or
+the [Bioc-devel](mailto:bioc-devel@r-project.org) mailing list.
+
+These issues can be questions about anything related to this piece of
+software such as, usage, extending Docker images, enhancements, and
+bug reports.
 
 ## Acknowledgements
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+services:
+  bioc:
+    image: "bioconductor/bioconductor_docker:devel"
+    ports:
+      - "8787:8787"
+    environment:
+      - PASSWORD=bioc
+    volumes:
+      - ${HOME}/R/bioconductor_docker/3.13:/usr/local/lib/R/host-site-library 
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3.9"
 services:
   bioc:
+    container_name: bioc-3.13
     image: "bioconductor/bioconductor_docker:devel"
     ports:
       - "8787:8787"
@@ -8,4 +9,4 @@ services:
       - PASSWORD=bioc
     volumes:
       - ${HOME}/R/bioconductor_docker/3.13:/usr/local/lib/R/host-site-library 
-    
+


### PR DESCRIPTION
This docker-compose file allows users to start up the bioconductor_docker image using the command 

```
docker-compose up
```

The environment variables are configured in the docker-compose.yaml file, so the user doesn't have to define 'PASSWORD` and `PORT`. 

The volume for libraries is autoconfigured to be stored on the users $HOME location under `$HOME/R/bioconductor_docker/<bioconductor_version>`.

This has been tested on Windows machines as well, and the volume mount seems to work in a similar way to Linux machines. 