### PR TITLE
Remove python2 completely from Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,15 +124,10 @@ RUN apt-get update \
 	&& rm -rf /var/lib/apt/lists/*
 
 ## Python installations
-RUN apt-get update \
-        ## Install sklearn and pandas on python
-        && pip3 install sklearn \
+RUN pip3 install sklearn \
         pandas \
-        pyyaml \
- 	&& apt-get clean \
- 	&& rm -rf /var/lib/apt/lists/*
+        pyyaml
  
-
 ## FIXME
 ## These two libraries don't install in the above section--WHY?
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,6 +120,8 @@ RUN apt-get update \
 	biber \
         libsbml5-dev \
         libzmq3-dev \
+        ## python3 dev
+        python3-dev \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,20 +125,13 @@ RUN apt-get update \
 
 ## Python installations
 RUN apt-get update \
-	&& apt-get install -y software-properties-common \
-	&& add-apt-repository universe \
-	&& apt-get update \
-	&& apt-get -y --no-install-recommends install python2 python-dev \
-	&& curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py \
-	&& python2 get-pip.py \
-	&& pip2 install wheel \
-	## Install sklearn and pandas on python
-	&& pip2 install sklearn \
-	pandas \
-	pyyaml \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& rm -rf get-pip.py
+        ## Install sklearn and pandas on python
+        && pip3 install sklearn \
+        pandas \
+        pyyaml \
+ 	&& apt-get clean \
+ 	&& rm -rf /var/lib/apt/lists/*
+ 
 
 ## FIXME
 ## These two libraries don't install in the above section--WHY?


### PR DESCRIPTION
- Only python3 is shipped with the docker image now.