### PR TITLE
Add libarchive-dev apt package

### DIFF
--- a/bioc_scripts/install_bioc_sysdeps.sh
+++ b/bioc_scripts/install_bioc_sysdeps.sh
@@ -66,7 +66,8 @@ apt-get install -y --no-install-recommends \
 	libsasl2-dev \
 	libpoppler-cpp-dev \
 	libprotobuf-dev \
-	libpq-dev
+	libpq-dev \
+	libarchive-dev
 
 ## software - perl extentions and modules
 apt-get install -y --no-install-recommends \


### PR DESCRIPTION
The Bioconductor AlpsNMR package has as dependency the archive package.

The archive CRAN package has as system requirement the libarchive-dev debian package.

Related to:
- https://github.com/Bioconductor/BBS/issues/220
- https://github.com/Bioconductor/BBS/pull/222

Thanks for your time.