### PR TITLE
Add BIOCONDUCTOR_USE_CONTAINER_REPOSITORY=FALSE before installations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ LABEL name="bioconductor/bioconductor_docker" \
       description="Bioconductor docker image with system dependencies to install all packages." \
       license="Artistic-2.0"
 
+## Do not use binary repositories during container creation
+## Avoid using binaries produced for older version of same container
+ENV BIOCONDUCTOR_USE_CONTAINER_REPOSITORY=FALSE
+
 ##  Add Bioconductor system dependencies
 ADD bioc_scripts/install_bioc_sysdeps.sh /tmp/
 RUN bash /tmp/install_bioc_sysdeps.sh
@@ -49,6 +53,9 @@ ENV LIBSBML_CFLAGS="-I/usr/include"
 ENV LIBSBML_LIBS="-lsbml"
 ENV BIOCONDUCTOR_DOCKER_VERSION=$BIOCONDUCTOR_DOCKER_VERSION
 ENV BIOCONDUCTOR_VERSION=$BIOCONDUCTOR_VERSION
+
+## Use binary repos after
+ENV BIOCONDUCTOR_USE_CONTAINER_REPOSITORY=TRUE
 
 # Init command for s6-overlay
 CMD ["/init"]


### PR DESCRIPTION
Fixes https://github.com/Bioconductor/bioconductor_docker/issues/59.

I went a bit in a circle trying to figure this one out, as I rebuilt binaries with new containers, but the binary for `stringi` seemed to not get updated. The issue was due to the fact that the `stringi` is a dependent package of one of the packages that we install beforehand in the docker image. After the change a few months ago to make `BiocManager::install` use binary repo (like previously only `AnVIL::install` would, the packages installed during the container building would use the binary repo, which prevented it from updating to the new container. The redis container building binaries inheriting from this, the old version of the library persisted. 

This change ensures that the libraries built in the docker image are built from source every time, ensuring that rebuilding of the same release version does not keep stale libraries.

Will push forward this to devel after merging in 3_16