### PR TITLE
New rocker builds

### DIFF
--- a/.github/scripts/rocker_prep.sh
+++ b/.github/scripts/rocker_prep.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+RVER=$1
+BIOCVER=$2
+ROCKERPREF=$3
+ARCH=$4
+
+git clone --depth 1 https://github.com/rocker-org/rocker-versioned2
+sed -i "s#rocker/r-ver:$RVER#$ROCKERPREF-r-ver:$RVER-$ARCH#g" rocker-versioned2/dockerfiles/rstudio_$RVER.Dockerfile
+sed -i "s#rocker/rstudio:$RVER#$ROCKERPREF-rstudio:$RVER-$ARCH#g" rocker-versioned2/dockerfiles/tidyverse_$RVER.Dockerfile
+sed -i "s#install_quarto.sh#install_quarto.sh || true#g" rocker-versioned2/dockerfiles/rstudio_$RVER.Dockerfile
+
+BIOC_MINOR=$(echo "$BIOCVER" | awk -F'.' '{print $NF}')
+echo "Bioconductor Version: $BIOCVER"
+if [ "$RVER" = "devel" ];
+then
+  if [ $((BIOC_MINOR%2)) -eq 0 ];
+  then
+      echo "Using latest release R since Bioc devel version is even";
+      sed -i "s#R_VERSION=$RVER#R_VERSION=latest#g" rocker-versioned2/dockerfiles/r-ver_$RVER.Dockerfile
+  else
+      echo "Using latest pre-release R since Bioc devel version is even";
+      sed -i "s#R_VERSION=$RVER#R_VERSION=patched#g" rocker-versioned2/dockerfiles/r-ver_$RVER.Dockerfile
+  fi
+fi

--- a/.github/workflows/build_containers.yaml
+++ b/.github/workflows/build_containers.yaml
@@ -14,10 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         base:
-          - {image: 'r-ver', amdtag: 'devel', armtag: 'N/A', outname: 'r-ver'}
-          - {image: 'rstudio', amdtag: 'devel', armtag: 'N/A', outname: 'bioconductor_docker'}
-          - {image: 'tidyverse', amdtag: 'devel', armtag: 'N/A', outname: 'tidyverse'}
-          - {image: 'ml-verse', amdtag: 'devel', armtag: 'N/A', outname: 'ml-verse'}
+          - {image: 'ghcr.io/bioconductor/rocker-r-ver', amdtag: 'devel-amd64', armtag: 'devel-arm64', outname: 'r-ver'}
+          - {image: 'ghcr.io/bioconductor/rocker-rstudio', amdtag: 'devel-amd64', armtag: 'devel-arm64', outname: 'bioconductor_docker'}
+          - {image: 'ghcr.io/bioconductor/rocker-tidyverse', amdtag: 'devel-amd64', armtag: 'N/A', outname: 'tidyverse'}
+          - {image: 'ghcr.io/bioconductor/rocker-ml-verse', amdtag: 'devel-amd64', armtag: 'N/A', outname: 'ml-verse'}
+
     name: Build branch images
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build_containers.yaml
+++ b/.github/workflows/build_containers.yaml
@@ -61,10 +61,21 @@ jobs:
         id: images
         run: |
           IMG=${{ steps.meta.outputs.tags }}
-          REPOLIST="docker.io/$IMG,ghcr.io/$IMG"
-          SUB="_docker"
-          # Also add alternative without _docker when in name
-          echo list=$(if [[ $REPOLIST == *$SUB* ]]; then echo "$REPOLIST,$(echo $REPOLIST | sed 's/_docker//g')"; else echo $REPOLIST; fi) >> $GITHUB_OUTPUT
+          REPOLIST="docker.io/$IMG"
+          REPOLIST="ghcr.io/$IMG,$REPOLIST"
+          # Add tag with tag 3.xx as well as RELEASE_3_xx
+          if [[ $IMG = *"RELEASE_"* ]]; then
+            REPOLIST="$(echo $REPOLIST | sed 's/:RELEASE_3_/:3./g'),$REPOLIST"
+          fi
+          # Add tag with R version (based on amd64)
+          docker pull ${{ matrix.base.image }}:${{ matrix.base.amdtag }}
+          RVER=$(docker inspect ${{ matrix.base.image }}:${{ matrix.base.amdtag }} | jq -r '.[].Config.Env[]|select(match("^R_VERSION"))|.[index("=")+1:]')
+          REPOLIST="$(echo $REPOLIST | sed "s/,/-R-$RVER,/g")-R-$RVER,$REPOLIST"
+                    # Also add alternative without _docker when in name
+          if [[ $REPOLIST == *"_docker"* ]]; then
+            REPOLIST="$(echo $REPOLIST | sed 's/_docker//g'),$REPOLIST"
+          fi
+          echo list=$REPOLIST >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -75,7 +86,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           build-args: |
-            BASE_IMAGE=rocker/${{ matrix.base.image }}
+            BASE_IMAGE=${{ matrix.base.image }}
             arm64_tag=${{ matrix.base.armtag }}
             amd64_tag=${{ matrix.base.amdtag }}
           file: Dockerfile
@@ -89,7 +100,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           build-args: |
-            BASE_IMAGE=rocker/${{ matrix.base.image }}
+            BASE_IMAGE=${{ matrix.base.image }}
             amd64_tag=${{ matrix.base.amdtag }}
           file: Dockerfile
           push: true

--- a/.github/workflows/daily-rocker-builds.yaml
+++ b/.github/workflows/daily-rocker-builds.yaml
@@ -1,0 +1,258 @@
+name: Extra rocker builds
+
+on:
+  workflow_dispatch:
+    inputs:
+      rver:
+        default: "devel"
+      biocver:
+        default: "3.17"
+  schedule:
+    - cron: '0 18 * * *'
+
+jobs:
+  buildrver:
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Free root space
+      uses: almahmoud/free-root-space@main
+      with:
+        verbose: true
+
+    - name: Set defaults for schedule
+      id: defs
+      run: |
+        echo rver=$(echo ${{ github.event.inputs.rver || 'devel' }}) >> $GITHUB_OUTPUT
+        echo biocver=$(echo ${{ github.event.inputs.biocver || '3.17' }}) >> $GITHUB_OUTPUT
+        echo registryuser=$(echo ${{ github.repository_owner }} | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
+        echo rockerintermediateprefix=$(echo "ghcr.io/${{ github.repository_owner }}/rocker" | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: arm64
+      if: matrix.arch == 'arm64'
+
+    - name: Login to GHCR
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set comma-separated list with all repository names
+      id: images
+      run: bash .github/scripts/rocker_prep.sh ${{ steps.defs.outputs.rver }} ${{ steps.defs.outputs.biocver }} ${{ steps.defs.outputs.rockerintermediateprefix }} ${{ matrix.arch }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        platforms: linux/${{ matrix.arch }}
+
+    - name: Build and push r-ver
+      uses: docker/build-push-action@v3
+      with:
+        file: rocker-versioned2/dockerfiles/r-ver_${{ steps.defs.outputs.rver }}.Dockerfile
+        context: rocker-versioned2
+        push: true
+        tags: ${{ steps.defs.outputs.rockerintermediateprefix }}-r-ver:${{ steps.defs.outputs.rver }}-${{ matrix.arch }}
+        platforms: linux/${{ matrix.arch }}
+
+  buildrstudio:
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    needs: buildrver
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Free root space
+      uses: almahmoud/free-root-space@main
+      with:
+        verbose: true
+
+    - name: Set defaults for schedule
+      id: defs
+      run: |
+        echo rver=$(echo ${{ github.event.inputs.rver || 'devel' }}) >> $GITHUB_OUTPUT
+        echo biocver=$(echo ${{ github.event.inputs.biocver || '3.17' }}) >> $GITHUB_OUTPUT
+        echo registryuser=$(echo ${{ github.repository_owner }} | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
+        echo rockerintermediateprefix=$(echo "ghcr.io/${{ github.repository_owner }}/rocker" | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: arm64
+      if: matrix.arch == 'arm64'
+
+    - name: Login to GHCR
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set comma-separated list with all repository names
+      id: images 
+      run: bash .github/scripts/rocker_prep.sh ${{ steps.defs.outputs.rver }} ${{ steps.defs.outputs.biocver }} ${{ steps.defs.outputs.rockerintermediateprefix }} ${{ matrix.arch }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        platforms: linux/${{ matrix.arch }}
+
+    - name: Build and push rstudio
+      uses: docker/build-push-action@v3
+      with:
+        file: rocker-versioned2/dockerfiles/rstudio_${{ steps.defs.outputs.rver }}.Dockerfile
+        context: rocker-versioned2
+        push: true
+        tags: ${{ steps.defs.outputs.rockerintermediateprefix }}-rstudio:${{ steps.defs.outputs.rver }}-${{ matrix.arch }}
+        platforms: linux/${{ matrix.arch }}
+
+  buildtidyverse:
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ubuntu-latest
+    needs: buildrstudio
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Free root space
+      uses: almahmoud/free-root-space@main
+      with:
+        verbose: true
+
+    - name: Set defaults for schedule
+      id: defs
+      run: |
+        echo rver=$(echo ${{ github.event.inputs.rver || 'devel' }}) >> $GITHUB_OUTPUT
+        echo biocver=$(echo ${{ github.event.inputs.biocver || '3.17' }}) >> $GITHUB_OUTPUT
+        echo registryuser=$(echo ${{ github.repository_owner }} | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
+        echo rockerintermediateprefix=$(echo "ghcr.io/${{ github.repository_owner }}/rocker" | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: arm64
+      if: matrix.arch == 'arm64'
+
+    - name: Login to GHCR
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set comma-separated list with all repository names
+      id: images
+      run: bash .github/scripts/rocker_prep.sh ${{ steps.defs.outputs.rver }} ${{ steps.defs.outputs.biocver }} ${{ steps.defs.outputs.rockerintermediateprefix }} ${{ matrix.arch }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        platforms: linux/${{ matrix.arch }}
+
+    - name: Build and push tidyverse
+      uses: docker/build-push-action@v3
+      with:
+        file: rocker-versioned2/dockerfiles/tidyverse_${{ steps.defs.outputs.rver }}.Dockerfile
+        context: rocker-versioned2
+        push: true
+        tags: ${{ steps.defs.outputs.rockerintermediateprefix }}-tidyverse:${{ steps.defs.outputs.rver }}-${{ matrix.arch }}
+        platforms: linux/${{ matrix.arch }}
+
+  mlbuild:
+    strategy:
+      matrix:
+        arch: [amd64]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Free root space
+      uses: almahmoud/free-root-space@main
+      with:
+        verbose: true
+
+    - name: Set defaults for schedule
+      id: defs
+      run: |
+        echo rver=$(echo ${{ github.event.inputs.rver || 'devel' }}) >> $GITHUB_OUTPUT
+        echo biocver=$(echo ${{ github.event.inputs.biocver || '3.17' }}) >> $GITHUB_OUTPUT
+        echo registryuser=$(echo ${{ github.repository_owner }} | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
+        echo rockerintermediateprefix=$(echo "ghcr.io/${{ github.repository_owner }}/rocker" | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: arm64
+      if: matrix.arch == 'arm64'
+
+    - name: Login to GHCR
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set comma-separated list with all repository names
+      id: images
+      run: |
+        ## git clone rocker
+        git clone --depth 1 https://github.com/rocker-org/rocker-versioned2
+        sed -i 's#rocker/cuda:${{ steps.defs.outputs.rver }}#${{ steps.defs.outputs.rockerintermediateprefix }}-cuda:${{ steps.defs.outputs.rver }}-${{ matrix.arch }}#g' rocker-versioned2/dockerfiles/ml_${{ steps.defs.outputs.rver }}.Dockerfile
+        sed -i 's#rocker/ml:${{ steps.defs.outputs.rver }}#${{ steps.defs.outputs.rockerintermediateprefix }}-ml:${{ steps.defs.outputs.rver }}-${{ matrix.arch }}#g' rocker-versioned2/dockerfiles/ml-verse_${{ steps.defs.outputs.rver }}.Dockerfile
+
+        BIOC_MINOR=$(echo "${{ steps.defs.outputs.biocver }}" | awk -F'.' '{print $NF}')
+        echo "Bioconductor Version: ${{ steps.defs.outputs.biocver }}"
+        if [ "${{ steps.defs.outputs.rver }}" = "devel" ];
+        then
+          if [ $((BIOC_MINOR%2)) -eq 0 ];
+          then
+              echo "Using latest release R since Bioc devel version is even";
+              sed -i 's#R_VERSION=${{ steps.defs.outputs.rver }}#R_VERSION=latest#g' rocker-versioned2/dockerfiles/cuda_${{ steps.defs.outputs.rver }}.Dockerfile
+          else
+              echo "Using latest pre-release R since Bioc devel version is even";
+              sed -i 's#R_VERSION=${{ steps.defs.outputs.rver }}#R_VERSION=patched#g' rocker-versioned2/dockerfiles/cuda_${{ steps.defs.outputs.rver }}.Dockerfile
+          fi
+        fi
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        platforms: linux/${{ matrix.arch }}
+
+    - name: Build and load cuda
+      uses: docker/build-push-action@v3
+      with:
+        file: rocker-versioned2/dockerfiles/cuda_${{ steps.defs.outputs.rver }}.Dockerfile
+        context: rocker-versioned2
+        push: true
+        tags: ${{ steps.defs.outputs.rockerintermediateprefix }}-cuda:${{ steps.defs.outputs.rver }}-${{ matrix.arch }}
+        platforms: linux/${{ matrix.arch }}
+
+    - name: Build and load ml
+      uses: docker/build-push-action@v3
+      with:
+        file: rocker-versioned2/dockerfiles/ml_${{ steps.defs.outputs.rver }}.Dockerfile
+        context: rocker-versioned2
+        push: true
+        tags: ${{ steps.defs.outputs.rockerintermediateprefix }}-ml:${{ steps.defs.outputs.rver }}-${{ matrix.arch }}
+        platforms: linux/${{ matrix.arch }}
+
+    - name: Build and load ml-verse
+      uses: docker/build-push-action@v3
+      with:
+        file: rocker-versioned2/dockerfiles/ml-verse_${{ steps.defs.outputs.rver }}.Dockerfile
+        context: rocker-versioned2
+        push: true
+        tags: ${{ steps.defs.outputs.rockerintermediateprefix }}-ml-verse:${{ steps.defs.outputs.rver }}-${{ matrix.arch }}
+        platforms: linux/${{ matrix.arch }}

--- a/.github/workflows/daily-rocker-builds.yaml
+++ b/.github/workflows/daily-rocker-builds.yaml
@@ -45,8 +45,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set comma-separated list with all repository names
-      id: images
+    - name: Prep rocker rocker files
       run: bash .github/scripts/rocker_prep.sh ${{ steps.defs.outputs.rver }} ${{ steps.defs.outputs.biocver }} ${{ steps.defs.outputs.rockerintermediateprefix }} ${{ matrix.arch }}
 
     - name: Set up Docker Buildx
@@ -98,9 +97,16 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set comma-separated list with all repository names
-      id: images 
-      run: bash .github/scripts/rocker_prep.sh ${{ steps.defs.outputs.rver }} ${{ steps.defs.outputs.biocver }} ${{ steps.defs.outputs.rockerintermediateprefix }} ${{ matrix.arch }}
+    - name: Prep rocker rocker files
+      run: |
+        bash .github/scripts/rocker_prep.sh ${{ steps.defs.outputs.rver }} ${{ steps.defs.outputs.biocver }} ${{ steps.defs.outputs.rockerintermediateprefix }} ${{ matrix.arch }}
+        
+
+    - name: Move some tidyverse builds to docker for arm64 to avoid timeout
+      run: |
+        head -n44 rocker-versioned2/scripts/install_tidyverse.sh >> rocker-versioned2/scripts/install_rstudio.sh
+        sed -i "\|RUN /rocker_scripts/install_rstudio.sh|i COPY scripts /rocker_scripts" rocker-versioned2/dockerfiles/rstudio_${{ steps.defs.outputs.rver }}.Dockerfile
+      if: matrix.arch == 'arm64'
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
@@ -151,8 +157,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set comma-separated list with all repository names
-      id: images
+    - name: Prep rocker rocker files
       run: bash .github/scripts/rocker_prep.sh ${{ steps.defs.outputs.rver }} ${{ steps.defs.outputs.biocver }} ${{ steps.defs.outputs.rockerintermediateprefix }} ${{ matrix.arch }}
 
     - name: Set up Docker Buildx
@@ -203,8 +208,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set comma-separated list with all repository names
-      id: images
+    - name: Prep rocker rocker files
       run: |
         ## git clone rocker
         git clone --depth 1 https://github.com/rocker-org/rocker-versioned2

--- a/.github/workflows/full-rstudio-build.yml
+++ b/.github/workflows/full-rstudio-build.yml
@@ -15,17 +15,34 @@ on:
   schedule:
     - cron: '0 18 * * 5'
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Push patch bump
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 50
+          shell: bash
+          command: |
+            set -x
+            git config --global --add safe.directory "$GITHUB_WORKSPACE"
+            git config user.name github-actions
+            git config user.email github-actions@github.com
+            git pull origin main || git reset --hard origin/main
+            sed -r -i 's/(^ARG BIOCONDUCTOR_PATCH=)([0-9]+)$/echo "\1$((\2+1))"/ge' Dockerfile
+            git add Dockerfile
+            git commit -m "Bump BIOCONDUCTOR_PATCH"
+            git push
+            
   build:
     strategy:
       matrix:
         arch: [amd64, arm64]
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    needs: bump
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v3
@@ -198,20 +215,3 @@ jobs:
           tar -xvf /tmp/image.tar
           sudo ls tmp/* | xargs -i bash -c "echo 'cat {}' && cat {}"
 
-      - name: Push patch bump
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 50
-          shell: bash
-          command: |
-            set -x
-            git config --global --add safe.directory "$GITHUB_WORKSPACE"
-            git config user.name github-actions
-            git config user.email github-actions@github.com
-            git pull origin main || git reset --hard origin/main
-            sed -r -i 's/(^ARG BIOCONDUCTOR_PATCH=)([0-9]+)$/echo "\1$((\2+1))"/ge' Dockerfile
-            git add Dockerfile
-            git commit -m "Bump BIOCONDUCTOR_PATCH"
-            git push
-            

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG TARGETARCH=amd64
 FROM base-$TARGETARCH AS base
 
 ## Set Dockerfile version number
-ARG BIOCONDUCTOR_VERSION=3.17
+ARG BIOCONDUCTOR_VERSION=3.16
 
 ##### IMPORTANT ########
 ## The PATCH version number should be incremented each time

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG TARGETARCH=amd64
 FROM base-$TARGETARCH AS base
 
 ## Set Dockerfile version number
-ARG BIOCONDUCTOR_VERSION=3.16
+ARG BIOCONDUCTOR_VERSION=3.17
 
 ##### IMPORTANT ########
 ## The PATCH version number should be incremented each time


### PR DESCRIPTION
- Adds daily rocker builds (notably needed for missing R 4.3 containers during 4.3 pre-release period)
- Re-aligns devel with latest RELEASE branch pre new release
- Makes Bioc's concept of `devel` follow pre-release/devel R during odd Bioc devel versions (eg: now for 3.17), and follow the current latest R when the Bioc devel version is even (eg: 3.18 should be running on 4.3, not 4.4)