### PR TITLE
fix: update curl to secured http link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ENV BIOCONDUCTOR_USE_CONTAINER_REPOSITORY=FALSE
 ADD bioc_scripts/install_bioc_sysdeps.sh /tmp/
 RUN bash /tmp/install_bioc_sysdeps.sh $BIOCONDUCTOR_VERSION \
     && echo "R_LIBS=/usr/local/lib/R/host-site-library:\${R_LIBS}" > /usr/local/lib/R/etc/Renviron.site \
-    && curl -O https://bioconductor.org/checkResults/devel/bioc-LATEST/Renviron.bioc \
+    && curl -OL http://bioconductor.org/checkResults/devel/bioc-LATEST/Renviron.bioc \
     && sed -i '/^IS_BIOC_BUILD_MACHINE/d' Renviron.bioc \
     && cat Renviron.bioc | grep -o '^[^#]*' | sed 's/export //g' >>/etc/environment \
     && cat Renviron.bioc >> /usr/local/lib/R/etc/Renviron.site \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ENV BIOCONDUCTOR_USE_CONTAINER_REPOSITORY=FALSE
 ADD bioc_scripts/install_bioc_sysdeps.sh /tmp/
 RUN bash /tmp/install_bioc_sysdeps.sh $BIOCONDUCTOR_VERSION \
     && echo "R_LIBS=/usr/local/lib/R/host-site-library:\${R_LIBS}" > /usr/local/lib/R/etc/Renviron.site \
-    && curl -O http://bioconductor.org/checkResults/devel/bioc-LATEST/Renviron.bioc \
+    && curl -O https://bioconductor.org/checkResults/devel/bioc-LATEST/Renviron.bioc \
     && sed -i '/^IS_BIOC_BUILD_MACHINE/d' Renviron.bioc \
     && cat Renviron.bioc | grep -o '^[^#]*' | sed 's/export //g' >>/etc/environment \
     && cat Renviron.bioc >> /usr/local/lib/R/etc/Renviron.site \


### PR DESCRIPTION
Not sure whether PRs are welcome for this repo, feel free to close it if not. 

The Dockerfile attempts to fetch `Renviron.bioc` hosted by Bioconductor, but it looks like unsecured HTTP links are not available anymore for `bioconductor.org` domain. 

```shell
$ curl http://bioconductor.org/checkResults/devel/bioc-LATEST/Renviron.bioc | head

<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>CloudFront</center>
</body>
</html>

$ curl https//bioconductor.org/checkResults/devel/bioc-LATEST/Renviron.bioc | head

# ====================================================================
# Environment variables used on the Bioconductor build machines to
# control the behavior of R 4.3 for the BioC 3.18 builds
# ====================================================================
#
# BIOCONDUCTOR PACKAGE DEVELOPERS/MAINTAINERS: Please use the settings
# below on your machine when working on the devel branch of your
# package. Also make sure to use a recent version of R 4.3. This
# should allow you to reproduce any error or warning you see on the
# Bioconductor build reports. The easiest way to use the settings
```

When in the `devel` docker container, this results in installation of system dependencies to fail when using this command (from [`neurogenomics/rworkflows`](https://github.com/neurogenomics/rworkflows/blob/master/action.yml)):

```shell
$ sysreqs=$(Rscript -e 'cat("apt-get update -y && apt-get install -y", paste(gsub("apt-get install -y ", "", remotes::system_requirements("ubuntu", "20.04")), collapse = " "))')

$ echo $sysreqs
File /usr/local/lib/R/etc//Renviron.site contains invalid line(s) <html> <head><title>301 Moved Permanently</title></head> <body> <center><h1>301 Moved Permanently</h1></center> <hr><center>CloudFront</center> </body> </html> They were ignored apt-get update -y && apt-get install -y libcurl4-openssl-dev libssl-dev pandoc make libicu-dev libxml2-dev
```

And more generally an invalid `Renviron.site` file:

```shell
$ R

   File /usr/local/lib/R/etc//Renviron.site contains invalid line(s)
      <html>
      <head><title>301 Moved Permanently</title></head>
      <body>
      <center><h1>301 Moved Permanently</h1></center>
      <hr><center>CloudFront</center>
      </body>
      </html>
   They were ignored


R version 4.3.1 (2023-06-16) -- "Beagle Scouts"
Copyright (C) 2023 The R Foundation for Statistical Computing
Platform: x86_64-pc-linux-gnu (64-bit)
```