### PR TITLE
Move 3.17 to R 4.3.1

### DIFF
--- a/.github/workflows/build_containers.yaml
+++ b/.github/workflows/build_containers.yaml
@@ -14,10 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         base:
-          - {image: 'rocker/r-ver', amdtag: '4.3.0', armtag: '4.3.0', outname: 'r-ver'}
-          - {image: 'ghcr.io/bioconductor/rocker-rstudio', amdtag: '4.3.0-amd64', armtag: '4.3.0-arm64', outname: 'bioconductor_docker'}
-          - {image: 'rocker/tidyverse', amdtag: '4.3.0', armtag: 'N/A', outname: 'tidyverse'}
-          - {image: 'ghcr.io/bioconductor/rocker-ml-verse', amdtag: '4.3.0-amd64', armtag: 'N/A', outname: 'ml-verse'}
+          - {image: 'rocker/r-ver', amdtag: '4.3.1', armtag: '4.3.1', outname: 'r-ver'}
+          - {image: 'rocker/rstudio', amdtag: '4.3.1', armtag: '4.3.1', outname: 'bioconductor_docker'}
+          - {image: 'rocker/tidyverse', amdtag: '4.3.1', armtag: 'N/A', outname: 'tidyverse'}
+          - {image: 'rocker/ml-verse', amdtag: '4.3.1', armtag: 'N/A', outname: 'ml-verse'}
 
     name: Build branch images
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Use rocker images instead of self-built now that rocker has all versions
- Move to 4.3.1 tag