### PR TITLE
Prepare for devel becoming 3.19

### DIFF
--- a/.github/workflows/daily-rocker-builds.yaml
+++ b/.github/workflows/daily-rocker-builds.yaml
@@ -6,7 +6,7 @@ on:
       rver:
         default: "devel"
       biocver:
-        default: "3.18"
+        default: "3.19"
   schedule:
     - cron: '0 18 * * *'
 
@@ -28,7 +28,7 @@ jobs:
       id: defs
       run: |
         echo rver=$(echo ${{ github.event.inputs.rver || 'devel' }}) >> $GITHUB_OUTPUT
-        echo biocver=$(echo ${{ github.event.inputs.biocver || '3.18' }}) >> $GITHUB_OUTPUT
+        echo biocver=$(echo ${{ github.event.inputs.biocver || '3.19' }}) >> $GITHUB_OUTPUT
         echo registryuser=$(echo ${{ github.repository_owner }} | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
         echo rockerintermediateprefix=$(echo "ghcr.io/${{ github.repository_owner }}/rocker" | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
 
@@ -80,7 +80,7 @@ jobs:
       id: defs
       run: |
         echo rver=$(echo ${{ github.event.inputs.rver || 'devel' }}) >> $GITHUB_OUTPUT
-        echo biocver=$(echo ${{ github.event.inputs.biocver || '3.18' }}) >> $GITHUB_OUTPUT
+        echo biocver=$(echo ${{ github.event.inputs.biocver || '3.19' }}) >> $GITHUB_OUTPUT
         echo registryuser=$(echo ${{ github.repository_owner }} | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
         echo rockerintermediateprefix=$(echo "ghcr.io/${{ github.repository_owner }}/rocker" | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
 
@@ -140,7 +140,7 @@ jobs:
       id: defs
       run: |
         echo rver=$(echo ${{ github.event.inputs.rver || 'devel' }}) >> $GITHUB_OUTPUT
-        echo biocver=$(echo ${{ github.event.inputs.biocver || '3.18' }}) >> $GITHUB_OUTPUT
+        echo biocver=$(echo ${{ github.event.inputs.biocver || '3.19' }}) >> $GITHUB_OUTPUT
         echo registryuser=$(echo ${{ github.repository_owner }} | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
         echo rockerintermediateprefix=$(echo "ghcr.io/${{ github.repository_owner }}/rocker" | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
 
@@ -191,7 +191,7 @@ jobs:
       id: defs
       run: |
         echo rver=$(echo ${{ github.event.inputs.rver || 'devel' }}) >> $GITHUB_OUTPUT
-        echo biocver=$(echo ${{ github.event.inputs.biocver || '3.18' }}) >> $GITHUB_OUTPUT
+        echo biocver=$(echo ${{ github.event.inputs.biocver || '3.19' }}) >> $GITHUB_OUTPUT
         echo registryuser=$(echo ${{ github.repository_owner }} | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
         echo rockerintermediateprefix=$(echo "ghcr.io/${{ github.repository_owner }}/rocker" | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
 

--- a/.github/workflows/full-rstudio-build.yml
+++ b/.github/workflows/full-rstudio-build.yml
@@ -9,7 +9,7 @@ on:
       rver:
         default: "devel"
       biocver:
-        default: "3.18"
+        default: "3.19"
       outname:
         default: "bioconductor_docker"
   schedule:
@@ -57,7 +57,7 @@ jobs:
       run: |
         echo outname=$(echo ${{ github.event.inputs.outname || 'bioconductor_docker' }}) >> $GITHUB_OUTPUT
         echo rver=$(echo ${{ github.event.inputs.rver || 'devel' }}) >> $GITHUB_OUTPUT
-        echo biocver=$(echo ${{ github.event.inputs.biocver || '3.18' }}) >> $GITHUB_OUTPUT
+        echo biocver=$(echo ${{ github.event.inputs.biocver || '3.19' }}) >> $GITHUB_OUTPUT
         echo registryuser=$(echo ${{ github.repository_owner }} | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
         echo rockerintermediateprefix=$(echo "ghcr.io/${{ github.repository_owner }}/rocker" | awk '{print tolower($0)}') >> $GITHUB_OUTPUT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ ENV TARGETARCH=${TARGETARCH:-amd64}
 FROM base-$TARGETARCH AS base
 
 ## Set Dockerfile version number
-ARG BIOCONDUCTOR_VERSION=3.18
+ARG BIOCONDUCTOR_VERSION=3.19
 
 ##### IMPORTANT ########
 ## The PATCH version number should be incremented each time
 ## there is a change in the Dockerfile.
-ARG BIOCONDUCTOR_PATCH=26
+ARG BIOCONDUCTOR_PATCH=0
 
 ARG BIOCONDUCTOR_DOCKER_VERSION=${BIOCONDUCTOR_VERSION}.${BIOCONDUCTOR_PATCH}
 
@@ -61,8 +61,8 @@ LABEL name="bioconductor/bioconductor_docker" \
       license="Artistic-2.0"
 
 # Reset args in last layer
-ARG BIOCONDUCTOR_VERSION=3.18
-ARG BIOCONDUCTOR_PATCH=26
+ARG BIOCONDUCTOR_VERSION=3.19
+ARG BIOCONDUCTOR_PATCH=0
 ARG BIOCONDUCTOR_DOCKER_VERSION=${BIOCONDUCTOR_VERSION}.${BIOCONDUCTOR_PATCH}
 
 # Set automatically when building with --platform

--- a/bioc_scripts/install_bioc_sysdeps.sh
+++ b/bioc_scripts/install_bioc_sysdeps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-BIOC_VERSION=${1:-"3.18"}
+BIOC_VERSION=${1:-"3.19"}
 
 # This is to avoid the error
 # 'debconf: unable to initialize frontend: Dialog'


### PR DESCRIPTION
- This PR should be merged after 3.19 source tarballs are pushed by the BBS.
- After that, the [full build](https://github.com/Bioconductor/bioconductor_docker/actions/workflows/full-rstudio-build.yml) and then the [extra rocker builds](https://github.com/Bioconductor/bioconductor_docker/actions/workflows/daily-rocker-builds.yaml) pipeline
- After both are done, the [container builds](https://github.com/Bioconductor/bioconductor_docker/actions/workflows/build_containers.yaml) should be triggered, in `devel` as well as one last time in `RELEASE_3_18` branch.