### PR TITLE
Automatic R devel version fix

### DIFF
--- a/.github/workflows/full-rstudio-build.yml
+++ b/.github/workflows/full-rstudio-build.yml
@@ -112,8 +112,8 @@ jobs:
               echo "Using latest release R since Bioc devel version is even";
               sed -i 's#R_VERSION=${{ steps.defs.outputs.rver }}#R_VERSION=latest#g' rocker-versioned2/dockerfiles/r-ver_${{ steps.defs.outputs.rver }}.Dockerfile
           else
-              echo "Using latest pre-release R since Bioc devel version is even";
-              sed -i 's#R_VERSION=${{ steps.defs.outputs.rver }}#R_VERSION=patched#g' rocker-versioned2/dockerfiles/r-ver_${{ steps.defs.outputs.rver }}.Dockerfile
+              echo "Using latest pre-release R since Bioc devel version is odd";
+              sed -i 's#R_VERSION=${{ steps.defs.outputs.rver }}#R_VERSION=devel#g' rocker-versioned2/dockerfiles/r-ver_${{ steps.defs.outputs.rver }}.Dockerfile
           fi
         fi
 

--- a/.github/workflows/full-rstudio-build.yml
+++ b/.github/workflows/full-rstudio-build.yml
@@ -109,11 +109,20 @@ jobs:
         then
           if [ $((BIOC_MINOR%2)) -eq 0 ];
           then
-              echo "Using latest release R since Bioc devel version is even";
-              sed -i 's#R_VERSION=${{ steps.defs.outputs.rver }}#R_VERSION=latest#g' rocker-versioned2/dockerfiles/r-ver_${{ steps.defs.outputs.rver }}.Dockerfile
+              echo "Using latest pre-release R from release track since Bioc devel version is even";
+              sed -i 's#R_VERSION=${{ steps.defs.outputs.rver }}#R_VERSION=patched#g' rocker-versioned2/dockerfiles/r-ver_${{ steps.defs.outputs.rver }}.Dockerfile
           else
-              echo "Using latest pre-release R since Bioc devel version is odd";
-              sed -i 's#R_VERSION=${{ steps.defs.outputs.rver }}#R_VERSION=devel#g' rocker-versioned2/dockerfiles/r-ver_${{ steps.defs.outputs.rver }}.Dockerfile
+              echo "Using devel pre-release R since Bioc devel version is odd";
+              curl -o ver-info.dcf https://cran.r-project.org/src/base/VERSION-INFO.dcf
+              REL_DATE=$(grep 'Date' ver-info.dcf | awk '{print $2}')
+              REL_VER_PATCH=$(grep 'Release' ver-info.dcf | awk '{print $2}' | awk -F'.' '{print $3}')
+              DEV_VER_PATCH=$(grep 'Devel' ver-info.dcf | awk '{print $2}' | awk -F'.' '{print $3}')
+              DATE_DIFF=$(echo $(date +%s) $(date -d "$REL_DATE" +%s) | awk '{print ($1 - $2) / 86400}')
+              DATE_DIFF="${DATE_DIFF%.*}"
+              # If release is less than a month old, and devel and release are both at patch 0, assume that it is the R release window when new Devel version is prepared but the release is not yet official
+              if [ "$DATE_DIFF" -lt 28 ] && [ "$REL_VER_PATCH" -eq 0 ] && [ "$DEV_VER_PATCH" -eq 0 ]; then
+                  sed -i 's#R_VERSION=${{ steps.defs.outputs.rver }}#R_VERSION=patched#g' rocker-versioned2/dockerfiles/r-ver_${{ steps.defs.outputs.rver }}.Dockerfile
+              fi
           fi
         fi
 

--- a/.github/workflows/full-rstudio-build.yml
+++ b/.github/workflows/full-rstudio-build.yml
@@ -102,28 +102,15 @@ jobs:
         git clone --depth 1 https://github.com/rocker-org/rocker-versioned2
         sed -i 's#rocker/r-ver:${{ steps.defs.outputs.rver }}#${{ steps.defs.outputs.rockerintermediateprefix }}-r-ver:${{ steps.defs.outputs.rver }}-${{ matrix.arch }}#g' rocker-versioned2/dockerfiles/rstudio_${{ steps.defs.outputs.rver }}.Dockerfile
         sed -i 's#install_quarto.sh#install_quarto.sh || true#g' rocker-versioned2/dockerfiles/rstudio_${{ steps.defs.outputs.rver }}.Dockerfile
-
-        BIOC_MINOR=$(echo "${{ steps.defs.outputs.biocver }}" | awk -F'.' '{print $NF}')
         echo "Bioconductor Version: ${{ steps.defs.outputs.biocver }}"
-        if [ "${{ steps.defs.outputs.rver }}" = "devel" ];
-        then
-          if [ $((BIOC_MINOR%2)) -eq 0 ];
-          then
-              echo "Using latest pre-release R from release track since Bioc devel version is even";
-              sed -i 's#R_VERSION=${{ steps.defs.outputs.rver }}#R_VERSION=patched#g' rocker-versioned2/dockerfiles/r-ver_${{ steps.defs.outputs.rver }}.Dockerfile
-          else
-              echo "Using devel pre-release R since Bioc devel version is odd";
-              curl -o ver-info.dcf https://cran.r-project.org/src/base/VERSION-INFO.dcf
-              REL_DATE=$(grep 'Date' ver-info.dcf | awk '{print $2}')
-              REL_VER_PATCH=$(grep 'Release' ver-info.dcf | awk '{print $2}' | awk -F'.' '{print $3}')
-              DEV_VER_PATCH=$(grep 'Devel' ver-info.dcf | awk '{print $2}' | awk -F'.' '{print $3}')
-              DATE_DIFF=$(echo $(date +%s) $(date -d "$REL_DATE" +%s) | awk '{print ($1 - $2) / 86400}')
-              DATE_DIFF="${DATE_DIFF%.*}"
-              # If release is less than a month old, and devel and release are both at patch 0, assume that it is the R release window when new Devel version is prepared but the release is not yet official
-              if [ "$DATE_DIFF" -lt 28 ] && [ "$REL_VER_PATCH" -eq 0 ] && [ "$DEV_VER_PATCH" -eq 0 ]; then
-                  sed -i 's#R_VERSION=${{ steps.defs.outputs.rver }}#R_VERSION=patched#g' rocker-versioned2/dockerfiles/r-ver_${{ steps.defs.outputs.rver }}.Dockerfile
-              fi
-          fi
+        if [ "${{ steps.defs.outputs.rver }}" = "devel" ]; then
+            echo "Using devel pre-release R since Bioc devel version is odd";
+            DEVEL_R_VER=$(curl https://bioconductor.org/config.yaml | grep '"${{ steps.defs.outputs.rver }}":' | awk '{print $2}' | sed 's/"//g')
+            REL_VER=$(curl https://cran.r-project.org/src/base/VERSION-INFO.dcf | grep "$DEVEL_R_VER" | awk -F':' '{print $1}')
+            # if the matching version is under release rather than devel, use patched pre-release rather than devel pre-release
+            if [ "$REL_VER" == "Release" ]; then 
+                sed -i 's#R_VERSION=${{ steps.defs.outputs.rver }}#R_VERSION=patched#g' rocker-versioned2/dockerfiles/r-ver_${{ steps.defs.outputs.rver }}.Dockerfile
+            fi
         fi
 
 


### PR DESCRIPTION
Previous iteration worked when it was implemented during the R 4.3.0 release window, but needs updating to work all the time. I tried a few different iterations, in the end using [config.yaml](https://www.bioconductor.org/config.yaml) to determine when the R version needed is latest release or latest devel.