### PR TITLE
Fixes the bug for automatic R version switch from devel to patched

### DIFF
--- a/.github/scripts/devel_or_patched_rversion.sh
+++ b/.github/scripts/devel_or_patched_rversion.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+BIOCVER=$1
+FILETOPATCH=$2
+
+DEVEL_R_VER=$(curl https://bioconductor.org/config.yaml | grep '_devel:' | awk '{print $2}' | sed 's/"//g')
+REL_VER=$(curl https://cran.r-project.org/src/base/VERSION-INFO.dcf | grep "$DEVEL_R_VER" | awk -F':' '{print $1}')
+# if the matching version is not under devel, use patched pre-release rather than devel pre-release
+if [ "$REL_VER" != "Devel" ]; then 
+    sed -i 's#R_VERSION=devel#R_VERSION=patched#g' "$FILETOPATCH"
+fi
+
+cat "$FILETOPATCH"

--- a/.github/scripts/rocker_prep.sh
+++ b/.github/scripts/rocker_prep.sh
@@ -9,13 +9,7 @@ sed -i "s#rocker/r-ver:$RVER#$ROCKERPREF-r-ver:$RVER-$ARCH#g" rocker-versioned2/
 sed -i "s#rocker/rstudio:$RVER#$ROCKERPREF-rstudio:$RVER-$ARCH#g" rocker-versioned2/dockerfiles/tidyverse_$RVER.Dockerfile
 sed -i "s#install_quarto.sh#install_quarto.sh || true#g" rocker-versioned2/dockerfiles/rstudio_$RVER.Dockerfile
 
-BIOC_MINOR=$(echo "$BIOCVER" | awk -F'.' '{print $NF}')
 echo "Bioconductor Version: $BIOCVER"
-if [ "$BIOCVER" = "devel" ]; then
-    DEVEL_R_VER=$(curl https://bioconductor.org/config.yaml | grep '"$BIOCVER":' | awk '{print $2}' | sed 's/"//g')
-    REL_VER=$(curl https://cran.r-project.org/src/base/VERSION-INFO.dcf | grep "$DEVEL_R_VER" | awk -F':' '{print $1}')
-    # if the matching version is under release rather than devel, use patched pre-release rather than devel pre-release
-    if [ "$REL_VER" == "Release" ]; then 
-        sed -i 's#R_VERSION=$BIOCVER#R_VERSION=patched#g' rocker-versioned2/dockerfiles/r-ver_$BIOCVER.Dockerfile
-    fi
+if [ "$RVER" == "devel" ]; then
+  bash .github/scripts/devel_or_patched_rversion.sh "$BIOCVER" "rocker-versioned2/dockerfiles/r-ver_$RVER.Dockerfile"
 fi

--- a/.github/workflows/daily-rocker-builds.yaml
+++ b/.github/workflows/daily-rocker-builds.yaml
@@ -37,6 +37,7 @@ jobs:
         echo latest-tag=$LATEST_TAG >> $GITHUB_OUTPUT
         if [ "$LATEST_TAG" == "$CURR_TAG" ]; then
           echo "Detected '$LATEST_TAG' == '$CURR_TAG' as latest available tag"
+          echo verdict="no"  >> $GITHUB_OUTPUT
         else
           mkdir -p ${{github.workspace}}/tmp/${{github.repository}}
           git clone https://github.com/${{github.repository}} -b ${{steps.defs.outputs.release-tag}} ${{github.workspace}}/tmp/${{github.repository}}
@@ -44,11 +45,13 @@ jobs:
           AUTO_BRANCH="auto-bump-${LATEST_TAG}"
           sed -i "s/$CURR_TAG/$LATEST_TAG/g" .github/workflows/build_containers.yaml
           sed -r -i 's/(^ARG BIOCONDUCTOR_PATCH=)([0-9]+)$/echo "\1$((\2+1))"/ge' Dockerfile
+          echo verdict="yes" >> $GITHUB_OUTPUT
         fi
 
     - name: Open pull request
       id: cpr
       uses: peter-evans/create-pull-request@v6
+      if: steps.rbump.outputs.verdict == 'yes'
       with:
           token: ${{secrets.PAT}}
           commit-message: Auto-bump ${{steps.rbump.outputs.latest-tag}}

--- a/.github/workflows/daily-rocker-builds.yaml
+++ b/.github/workflows/daily-rocker-builds.yaml
@@ -268,15 +268,9 @@ jobs:
         sed -i 's#rocker/cuda:${{ steps.defs.outputs.rver }}#${{ steps.defs.outputs.rockerintermediateprefix }}-cuda:${{ steps.defs.outputs.rver }}-${{ matrix.arch }}#g' rocker-versioned2/dockerfiles/ml_${{ steps.defs.outputs.rver }}.Dockerfile
         sed -i 's#rocker/ml:${{ steps.defs.outputs.rver }}#${{ steps.defs.outputs.rockerintermediateprefix }}-ml:${{ steps.defs.outputs.rver }}-${{ matrix.arch }}#g' rocker-versioned2/dockerfiles/ml-verse_${{ steps.defs.outputs.rver }}.Dockerfile
 
-        BIOC_MINOR=$(echo "${{ steps.defs.outputs.biocver }}" | awk -F'.' '{print $NF}')
         echo "Bioconductor Version: ${{ steps.defs.outputs.biocver }}"
-        if [ "${{ steps.defs.outputs.rver }}" = "devel" ]; then
-            DEVEL_R_VER=$(curl https://bioconductor.org/config.yaml | grep '"${{ steps.defs.outputs.rver }}":' | awk '{print $2}' | sed 's/"//g')
-            REL_VER=$(curl https://cran.r-project.org/src/base/VERSION-INFO.dcf | grep "$DEVEL_R_VER" | awk -F':' '{print $1}')
-            # if the matching version is under release rather than devel, use patched pre-release rather than devel pre-release
-            if [ "$REL_VER" == "Release" ]; then 
-                sed -i 's#R_VERSION=${{ steps.defs.outputs.rver }}#R_VERSION=patched#g' rocker-versioned2/dockerfiles/cuda_${{ steps.defs.outputs.rver }}.Dockerfile
-            fi
+        if [ "${{ steps.defs.outputs.rver }}" == "devel" ]; then
+          bash .github/scripts/devel_or_patched_rversion.sh "${{ steps.defs.outputs.biocver }}" "rocker-versioned2/dockerfiles/cuda_${{ steps.defs.outputs.rver }}.Dockerfile"
         fi
 
     - name: Set up Docker Buildx

--- a/.github/workflows/full-rstudio-build.yml
+++ b/.github/workflows/full-rstudio-build.yml
@@ -102,21 +102,7 @@ jobs:
         # Also add alternative without _docker when in name
         echo list=$(if [[ $REPOLIST == *$SUB* ]]; then echo "$REPOLIST,$(echo $REPOLIST | sed 's/_docker//g')"; else echo $REPOLIST; fi) >> $GITHUB_OUTPUT
 
-        ## git clone rocker
-        git clone --depth 1 https://github.com/rocker-org/rocker-versioned2
-        sed -i 's#rocker/r-ver:${{ steps.defs.outputs.rver }}#${{ steps.defs.outputs.rockerintermediateprefix }}-r-ver:${{ steps.defs.outputs.rver }}-${{ matrix.arch }}#g' rocker-versioned2/dockerfiles/rstudio_${{ steps.defs.outputs.rver }}.Dockerfile
-        sed -i 's#install_quarto.sh#install_quarto.sh || true#g' rocker-versioned2/dockerfiles/rstudio_${{ steps.defs.outputs.rver }}.Dockerfile
-        echo "Bioconductor Version: ${{ steps.defs.outputs.biocver }}"
-        if [ "${{ steps.defs.outputs.rver }}" = "devel" ]; then
-            echo "Using devel pre-release R since Bioc devel version is odd";
-            DEVEL_R_VER=$(curl https://bioconductor.org/config.yaml | grep '"${{ steps.defs.outputs.rver }}":' | awk '{print $2}' | sed 's/"//g')
-            REL_VER=$(curl https://cran.r-project.org/src/base/VERSION-INFO.dcf | grep "$DEVEL_R_VER" | awk -F':' '{print $1}')
-            # if the matching version is under release rather than devel, use patched pre-release rather than devel pre-release
-            if [ "$REL_VER" == "Release" ]; then 
-                sed -i 's#R_VERSION=${{ steps.defs.outputs.rver }}#R_VERSION=patched#g' rocker-versioned2/dockerfiles/r-ver_${{ steps.defs.outputs.rver }}.Dockerfile
-            fi
-        fi
-
+        bash .github/scripts/rocker_prep.sh "${{ steps.defs.outputs.rver }}" "${{ steps.defs.outputs.biocver }}" "${{ steps.defs.outputs.rockerintermediateprefix }}" "${{ matrix.arch }}"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
Consolidates logic for checking R version for rocker Dockerfiles to a separate script, instead of repeated multiple times across workflows.
Also makes the version check for auto-bumping of release R version pass instead of fail at last step if a bump is not needed