### PR TITLE
Add default packages fro the Galaxy extension

### DIFF
--- a/extensions/galaxy/Dockerfile
+++ b/extensions/galaxy/Dockerfile
@@ -1,6 +1,13 @@
 ARG BASE_IMAGE=ghcr.io/bioconductor/bioconductor_docker
-ARG TAG=devel
+ARG TAG=3.20
 
 FROM ${BASE_IMAGE}:${TAG}
-RUN apt update -y && apt install -y net-tools python3-bioblend && Rscript -e 'BiocManager::install("hexylena/rGalaxyConnector")' && pip3 install galaxy-ie-helpers --break-system-packages && alias ll='ls -l' && echo "alias ll='ls -l'" >> ~/.bashrc
+RUN apt update -y && apt install -y net-tools python3-bioblend && \
+    Rscript -e 'BiocManager::install(c("Biobase", "BiocGenerics", "Biostrings", "cummeRbund", "DESeq2", "dplyr", "edgeR", "GenomeInfoDb", "ggplot2", "ggvis", "Gviz", "hexylena/rGalaxyConnector", "IRanges", "limma", "RCurl", "reshape2", "Rgraphviz", "RODBC", "Rsamtools", "S4Vectors", "shiny", "SummarizedExperiment", "tidyr", "XML"))' && \
+    pip3 install galaxy-ie-helpers --break-system-packages && \
+    chown -R rstudio:rstudio /usr/local/lib/R/library && \
+    chown -R rstudio:rstudio /usr/local/lib/R/doc && \
+    echo "alias ll='ls -l'" >> ~/.bashrc && \
+    apt-get autoremove -y && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
 ENV PIP_USER=0


### PR DESCRIPTION
The list of packages is largely based on the current default image use by Galaxy (https://github.com/hexylena/docker-rstudio-notebook/blob/a92e9110b616277c6963c6b8c640c535c41585d0/requirements.txt) and the top 10 downloaded packages from Bioconductor Stats page (https://www.bioconductor.org/packages/stats/).