### PR TITLE
Add nginx need by usegalaxy

### DIFF
--- a/extensions/galaxy/Dockerfile
+++ b/extensions/galaxy/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ghcr.io/bioconductor/bioconductor_docker
 ARG TAG=3.20
 
 FROM ${BASE_IMAGE}:${TAG}
-RUN apt update -y && apt install -y net-tools python3-bioblend && \
+RUN apt update -y && apt install -y net-tools python3-bioblend nginx && \
     Rscript -e 'BiocManager::install(c("Biobase", "BiocGenerics", "Biostrings", "cummeRbund", "DESeq2", "dplyr", "edgeR", "GenomeInfoDb", "ggplot2", "ggvis", "Gviz", "hexylena/rGalaxyConnector", "IRanges", "limma", "RCurl", "reshape2", "Rgraphviz", "RODBC", "Rsamtools", "S4Vectors", "shiny", "SummarizedExperiment", "tidyr", "XML"))' && \
     pip3 install galaxy-ie-helpers --break-system-packages && \
     chown -R rstudio:rstudio /usr/local/lib/R/library && \
@@ -10,4 +10,11 @@ RUN apt update -y && apt install -y net-tools python3-bioblend && \
     echo "alias ll='ls -l'" >> ~/.bashrc && \
     apt-get autoremove -y && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN mkdir -p /etc/services.d/nginx
+COPY service-nginx-start /etc/services.d/nginx/run
+COPY proxy.conf /etc/nginx/sites-enabled/default
+
 ENV PIP_USER=0
+
+EXPOSE 8780

--- a/extensions/galaxy/proxy.conf
+++ b/extensions/galaxy/proxy.conf
@@ -1,0 +1,21 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 8780;
+
+    location / {
+        proxy_pass     http://localhost:8787;
+        proxy_redirect http://localhost:8787/ $scheme://$http_host/;
+        proxy_http_version 1.1;
+
+        proxy_set_header    Connection $http_connection;
+        proxy_set_header    Upgrade $http_upgrade;
+        proxy_set_header    X-Forwarded-Protocol $scheme;
+        proxy_set_header    X-Scheme $scheme;
+        proxy_set_header    X-Real-IP $remote_addr;
+        proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/extensions/galaxy/service-nginx-start
+++ b/extensions/galaxy/service-nginx-start
@@ -1,0 +1,16 @@
+#!/usr/bin/with-contenv bash
+env > /asdf
+
+# Pass some system environment variables to RStudio environment
+echo "Sys.setenv(DEBUG=\"$DEBUG\")
+Sys.setenv(GALAXY_WEB_PORT=\"$GALAXY_WEB_PORT\")
+Sys.setenv(CORS_ORIGIN=\"$CORS_ORIGIN\")
+Sys.setenv(DOCKER_PORT=\"$DOCKER_PORT\")
+Sys.setenv(API_KEY=\"$API_KEY\")
+Sys.setenv(HISTORY_ID=\"$HISTORY_ID\")
+Sys.setenv(REMOTE_HOST=\"$REMOTE_HOST\")
+Sys.setenv(GALAXY_URL=\"$GALAXY_URL\")
+" >> /usr/local/lib/R/etc/Rprofile.site
+
+# And nginx in foreground mode.
+nginx -g 'daemon off;'


### PR DESCRIPTION
Without a proxy internal to the container, this image did not work on [test.usegalax.org](https://test.galaxyproject.org/), supposedly due to connection closing prematurely. This has been a workaround with the previous image, which I just ported here. Tested it locally and on Test with success. 