### PR TITLE
Add 'latest' tag to Galaxy extension

### DIFF
--- a/extensions/galaxy/bioc-extension.yaml
+++ b/extensions/galaxy/bioc-extension.yaml
@@ -5,3 +5,4 @@ container:
     tag:
       - "RELEASE_3_22"
       - "devel"
+      - "latest"

--- a/extensions/galaxy/bioc-extension.yaml
+++ b/extensions/galaxy/bioc-extension.yaml
@@ -3,6 +3,7 @@ container:
   base:
     image: ghcr.io/bioconductor/bioconductor
     tag:
+      - "RELEASE_3_21"
       - "RELEASE_3_22"
       - "devel"
       - "latest"


### PR DESCRIPTION
@afgane I just saw and merged https://github.com/Bioconductor/bioconductor_docker/pull/131, thoughts on also adding the `latest` tag, which automatically points to the latest release, so that there is an easy way to get latest release automatically while also keeping pinned tags to be able to get previous release versions?